### PR TITLE
Fix: typo Comments should be comments

### DIFF
--- a/SecAura Blog PHP Web App/README.md
+++ b/SecAura Blog PHP Web App/README.md
@@ -5,7 +5,7 @@
 
 > Access /phpmyadmin, create table:
 
-    CREATE TABLE Comments (
+    CREATE TABLE comments (
         id int NOT NULL AUTO_INCREMENT,
         name varchar(255) NOT NULL,
         usercomment varchar(255),


### PR DESCRIPTION
If you follow the instructions listed below you won't be able to make a comment. This is due to the instructions stating to create the `Comments` table when the php code uses `comments` (notice the lowercase c).

from my php_error_log:

` Uncaught mysqli_sql_exception: Table 'blog.comments' doesn't exist in ...`

https://github.com/SecAuraYT/OSWE/blob/c9d8ae3bdb352ecdf16d619eefbc08e9ccb3348e/SecAura%20Blog%20PHP%20Web%20App/Index.php#L47

Tested with lampp 8.1.1 on Kali Linux 2021.4 x64